### PR TITLE
Added a byValue() static method

### DIFF
--- a/src/GerritDrost/Lib/Enum/Enum.php
+++ b/src/GerritDrost/Lib/Enum/Enum.php
@@ -86,6 +86,25 @@ abstract class Enum
     }
 
     /**
+     * Returns the enum instance that matches the provided const value, or null when the const value is not present in
+     * the enum.
+     *
+     * @param mixed $value
+     *
+     * @return Enum|null
+     */
+    public static function byValue($value)
+    {
+        foreach (self::getEnumValues() as $enumValue) {
+            if ($enumValue->getConstValue() === $value) {
+                return $enumValue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Returns all value singletons of this enum
      *
      * @return Enum[]

--- a/tests/GerritDrost/Lib/Enum/EnumTest.php
+++ b/tests/GerritDrost/Lib/Enum/EnumTest.php
@@ -36,6 +36,25 @@ class EnumTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($fooByName->equals($barByName));
     }
 
+    public function testByValue()
+    {
+        $foo = FoobarEnum::FOO();
+        $fooByValue = FoobarEnum::byValue(0);
+
+        $this->assertNotNull($fooByValue);
+        $this->assertTrue($foo->equals($fooByValue));
+        $this->assertSame($foo, $fooByValue);
+
+        $bar = FoobarEnum::BAR();
+        $barByValue = FoobarEnum::byValue(1);
+
+        $this->assertNotNull($barByValue);
+        $this->assertTrue($bar->equals($barByValue));
+        $this->assertSame($bar, $barByValue);
+
+        $this->assertFalse($fooByValue->equals($barByValue));
+    }
+
     public function testExistingConst()
     {
         $foo = FoobarEnum::FOO();


### PR DESCRIPTION
This is mostly just a convenience method that allows users to fetch an enum instance by const value instead of by const name. It iterates through the getEnumValues() array to find a matching instance, so it's not the fastest possible solution, but it doesn't require any additional memory use.

I've also added a test for this new method, based on the one for byName().